### PR TITLE
Fix premium pass recovery when cookies are not saved

### DIFF
--- a/worker/access.ts
+++ b/worker/access.ts
@@ -1,10 +1,3 @@
-/**
- * Signed access passes for paid articles. After a successful payment the Worker
- * issues an HMAC-SHA256 signed, slug-scoped, expiring token stored as a cookie,
- * so the reader isn't charged again on reload within its TTL. The signing key
- * (ACCESS_TOKEN_SECRET) is a Worker secret, never committed.
- */
-
 const COOKIE_PREFIX = 'premium_'
 const encoder = new TextEncoder()
 
@@ -49,7 +42,10 @@ function parseCookie(header: string, name: string): string | undefined {
   return undefined
 }
 
-/** Issue a slug-scoped token valid for ttlSeconds. */
+export function passName(slug: string): string {
+  return `${COOKIE_PREFIX}${slug}`
+}
+
 export async function issueToken(
   slug: string,
   secret: string,
@@ -62,11 +58,6 @@ export async function issueToken(
   return `${payload}.${sig}`
 }
 
-/**
- * Set-Cookie header value scoping the pass to this article's premium path.
- * `Secure` is only added over HTTPS — Safari refuses to store Secure cookies
- * on http://localhost, which would break the pass during local dev.
- */
 export function passCookie(
   slug: string,
   token: string,
@@ -74,17 +65,14 @@ export function passCookie(
   secure: boolean,
 ): string {
   const attrs = `Path=/premium/${slug}; Max-Age=${ttlSeconds}; HttpOnly; SameSite=Lax`
-  return `${COOKIE_PREFIX}${slug}=${token}; ${attrs}${secure ? '; Secure' : ''}`
+  return `${passName(slug)}=${token}; ${attrs}${secure ? '; Secure' : ''}`
 }
 
-/** True if the Cookie header carries a valid, unexpired pass for slug. */
-export async function hasValidPass(
-  cookieHeader: string | undefined,
+export async function hasValidPassToken(
+  token: string | undefined,
   slug: string,
   secret: string,
 ): Promise<boolean> {
-  if (!cookieHeader) return false
-  const token = parseCookie(cookieHeader, `${COOKIE_PREFIX}${slug}`)
   if (!token) return false
   const [payload, sig] = token.split('.')
   if (!payload || !sig) return false
@@ -98,4 +86,13 @@ export async function hasValidPass(
   } catch {
     return false
   }
+}
+
+export async function hasValidPass(
+  cookieHeader: string | undefined,
+  slug: string,
+  secret: string,
+): Promise<boolean> {
+  if (!cookieHeader) return false
+  return hasValidPassToken(parseCookie(cookieHeader, passName(slug)), slug, secret)
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -5,7 +5,7 @@ import { createPaywall } from '@x402/paywall'
 import { evmPaywall } from '@x402/paywall/evm'
 import { content, premium } from './content.generated.js'
 import { isAiCrawler } from './crawlers'
-import { hasValidPass, issueToken, passCookie } from './access'
+import { hasValidPass, hasValidPassToken, issueToken, passCookie } from './access'
 import { getFacilitator } from './facilitator'
 
 interface Env {
@@ -76,6 +76,22 @@ function gate(env: Env, routeKey: string, price: string, description: string) {
   return middleware
 }
 
+function premiumUrl(slug: string): string {
+  return `/premium/${encodeURIComponent(slug)}`
+}
+
+function accessUrl(slug: string, token: string): string {
+  return `/access/${encodeURIComponent(slug)}?token=${encodeURIComponent(token)}`
+}
+
+function addRecoveryLink(html: string, slug: string, token: string): string {
+  const link = accessUrl(slug, token)
+  const note = `<div class="paywall-recovery" style="margin:1rem 0;padding:1rem;border:1px solid currentColor"><p>如果浏览器没有保存 cookie，请保存下面的恢复链接，之后可用它恢复本文访问，不需要再次付款。</p><p><a href="${link}">恢复访问链接</a></p></div>`
+  return html.includes('<article class="blog-article">')
+    ? html.replace('<article class="blog-article">', `<article class="blog-article">${note}`)
+    : `${note}${html}`
+}
+
 app.use('/api/content/*', async (c, next) => {
   const slug = c.req.path.split('/').pop() ?? ''
   if (!(slug in articles)) return c.json({ error: 'Not found', slug }, 404)
@@ -107,6 +123,26 @@ app.use('/posts/*', async (c, next) => {
     return r
   }
   return res
+})
+
+app.get('/access/:slug', async (c) => {
+  const slug = c.req.param('slug')
+  if (!(slug in premiumArticles)) return c.text('Not found', 404)
+
+  if (await hasValidPass(c.req.header('cookie'), slug, c.env.ACCESS_TOKEN_SECRET)) {
+    return c.redirect(premiumUrl(slug), 302)
+  }
+
+  const token = c.req.query('token')
+  if (!(await hasValidPassToken(token, slug, c.env.ACCESS_TOKEN_SECRET))) {
+    return c.redirect(premiumUrl(slug), 302)
+  }
+
+  const ttl = Number(c.env.PASS_TTL_SECONDS)
+  const secure = new URL(c.req.url).protocol === 'https:'
+  c.header('Set-Cookie', passCookie(slug, token!, ttl, secure))
+  c.header('Cache-Control', 'no-store')
+  return c.redirect(premiumUrl(slug), 302)
 })
 
 app.use('/premium/*', async (c, next) => {
@@ -147,7 +183,10 @@ app.use('/premium/*', async (c, next) => {
     const ttl = Number(c.env.PASS_TTL_SECONDS)
     const token = await issueToken(slug, c.env.ACCESS_TOKEN_SECRET, ttl)
     const secure = new URL(c.req.url).protocol === 'https:'
-    out.headers.append('Set-Cookie', passCookie(slug, token, ttl, secure))
+    const paid = new Response(addRecoveryLink(await out.text(), slug, token), out)
+    paid.headers.delete('Content-Length')
+    paid.headers.append('Set-Cookie', passCookie(slug, token, ttl, secure))
+    return paid
   }
 
   return out


### PR DESCRIPTION
## Summary

This PR adds a fallback recovery flow for premium article access when the browser fails to persist the `premium_<slug>` cookie after a successful x402 payment.

## Changes

- Reuses the same signed pass token for both the HTTP-only cookie and a one-time recovery link shown after successful settlement.
- Adds `/access/:slug?token=...` to validate the signed token, restore the cookie, and redirect back to `/premium/:slug`.
- Keeps the existing guard that only issues a pass after `X-PAYMENT-RESPONSE` is present, so unpaid requests still cannot mint access.
- Adds `hasValidPassToken()` so the Worker can validate pass tokens from the recovery route without trusting raw input.

## Notes

This solves same-browser/session recovery only if the user keeps the recovery link. Full cross-device recovery would still need server-side storage such as D1/KV keyed by payer wallet or settlement transaction.